### PR TITLE
fix: Convert generators to bytes in ToSpeech RPC method

### DIFF
--- a/src/speech_service_api/api.py
+++ b/src/speech_service_api/api.py
@@ -106,6 +106,12 @@ class SpeechRPCService(SpeechServiceBase, ResourceRPCServiceBase):
         name = request.name
         service = self.get_resource(name)
         resp = await service.to_speech(request.text)
+        if not isinstance(resp, bytes):
+            if hasattr(resp, '__aiter__'):
+                chunks = [chunk async for chunk in resp]
+                resp = b''.join(chunks)
+            elif hasattr(resp, '__iter__'):
+                resp = b''.join(resp)
         await stream.send_message(ToSpeechResponse(speech=resp))
 
     async def Completion(


### PR DESCRIPTION
This PR fixes the "TypeError - expected bytes, generator found" error when using the Go client with ToSpeech.

Problem: When speech service implementations return generators from to_speech() instead of bytes, the Go client fails.

Solution: The RPC service now automatically detects and consumes generators, converting them to bytes before sending the response.